### PR TITLE
Update requirements and assert to work with node v22

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is ready to be used but only work with the latest version of [simpl
 
 In order to run this project, you will need to install globally the following dependencies:
 
-- **node >=18.11.0**
+- **node >=22.2.0**
 - **npm**
 - **pm2 >=5.3.0**
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 import http from "http";
 import { WebSocketServer } from "ws";
 import { exec } from "child_process";
-import config from "./config.json" assert { type: "json" };
+import config from "./config.json" with { type: "json" };
+// import config from "./config.json";
 import widgetAction from "./services/widget.js";
 import yabaiAction from "./services/yabai.js";
 import skhdAction from "./services/skhd.js";


### PR DESCRIPTION
- Change required node version to 22.2.0 (tested version, perhaps earlier v22 subversions could work)
- Change assert keyword to with in import statements of json file in index.js